### PR TITLE
dismissNavigationAlert handled as promise

### DIFF
--- a/packages/react-native-carplay/ios/RNCarPlay.m
+++ b/packages/react-native-carplay/ios/RNCarPlay.m
@@ -971,11 +971,15 @@ RCT_EXPORT_METHOD(presentNavigationAlert:(NSString*)templateId json:(NSDictionar
     }
 }
 
-RCT_EXPORT_METHOD(dismissNavigationAlert:(NSString*)templateId animated:(BOOL)animated) {
+RCT_EXPORT_METHOD(dismissNavigationAlert:(NSString*)templateId animated:(BOOL)animated resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
     CPTemplate *template = [[RNCPStore sharedManager] findTemplateById:templateId];
     if (template) {
         CPMapTemplate *mapTemplate = (CPMapTemplate*) template;
-        [mapTemplate dismissNavigationAlertAnimated:animated completion:^(BOOL completion) { }];
+        [mapTemplate dismissNavigationAlertAnimated:animated completion:^(BOOL completion) {
+            resolve(completion);
+        }];
+    } else {
+        reject(@"template_not_found", @"Template not found", nil);
     }
 }
 

--- a/packages/react-native-carplay/src/interfaces/InternalCarPlay.ts
+++ b/packages/react-native-carplay/src/interfaces/InternalCarPlay.ts
@@ -42,7 +42,7 @@ export interface InternalCarPlay extends NativeModule {
   showTripPreviews(id: string, previews: string[], config: TextConfiguration): void;
   showRouteChoicesPreviewForTrip(id: string, tripId: string, config: TextConfiguration): void;
   presentNavigationAlert(id: string, config: unknown, animated: boolean): void;
-  dismissNavigationAlert(id: string, animated: boolean): void;
+  dismissNavigationAlert(id: string, animated: boolean): Promise<boolean>;
   showPanningInterface(id: string, animated: boolean): void;
   dismissPanningInterface(id: string, animated: boolean): void;
   getMaximumListSectionCount(id: string): Promise<number>;

--- a/packages/react-native-carplay/src/templates/MapTemplate.ts
+++ b/packages/react-native-carplay/src/templates/MapTemplate.ts
@@ -329,8 +329,13 @@ export class MapTemplate extends Template<MapTemplateConfig> {
     CarPlay.bridge.presentNavigationAlert(this.id, config, animated);
   }
 
+  /**
+   * Dismisses the currently shown navigation alert. This function is async and should be awaited before showing a new alert dialog.
+   * @param animated A Boolean value that determines whether to animate the dismissal of the alert dialog.
+   * @returns A Promise that indicates if the alert dialog dismissal was successful
+   */
   public dismissNavigationAlert(animated = true) {
-    CarPlay.bridge.dismissNavigationAlert(this.id, animated);
+    return CarPlay.bridge.dismissNavigationAlert(this.id, animated);
   }
 
   /**


### PR DESCRIPTION
dismissNavigationAlert is async on carplay side, so we need to be able to await it before sending in a new alert dialog