### PR TITLE
feat: fix TabTemplate not working in Android

### DIFF
--- a/packages/react-native-carplay/android/.npmignore
+++ b/packages/react-native-carplay/android/.npmignore
@@ -1,2 +1,36 @@
 # .npmignore
-build
+# Gradle files
+.gradle/
+build/
+gradle
+
+# Local configuration file (sdk path, etc)
+local.properties
+
+# Log/OS Files
+*.log
+
+# Android Studio generated files and folders
+captures/
+.externalNativeBuild/
+.cxx/
+*.aab
+*.apk
+output-metadata.json
+
+# IntelliJ
+*.iml
+.idea/
+misc.xml
+deploymentTargetDropDown.xml
+render.experimental.xml
+
+# Keystore files
+*.jks
+*.keystore
+
+# Google Services (e.g. APIs or Firebase)
+google-services.json
+
+# Android Profiling
+*.hprof

--- a/packages/react-native-carplay/android/src/main/java/org/birkir/carplay/CarPlayModule.kt
+++ b/packages/react-native-carplay/android/src/main/java/org/birkir/carplay/CarPlayModule.kt
@@ -11,6 +11,7 @@ import androidx.car.app.CarToast
 import androidx.car.app.ScreenManager
 import androidx.car.app.model.Alert
 import androidx.car.app.model.AlertCallback
+import androidx.car.app.model.TabTemplate
 import androidx.car.app.model.Template
 import androidx.car.app.navigation.model.NavigationTemplate
 import androidx.lifecycle.DefaultLifecycleObserver
@@ -145,6 +146,10 @@ class CarPlayModule internal constructor(private val reactContext: ReactApplicat
               // cluster can hold NavigationTemplate only and always has a surface to render to
               it.key.setTemplate(template = clusterTemplate, invalidate = true, isSurfaceTemplate = true, sessionLifecycle = sessionLifecycle)
             }
+          }
+          if (template is TabTemplate) {
+            carScreens[carScreenContext.screenMarker]?.setTemplate(template, invalidate = true, isSurfaceTemplate = true, sessionLifecycle = sessionLifecycle)
+            carScreens[carScreenContext.screenMarker]?.invalidate()
           }
         }
       }

--- a/packages/react-native-carplay/android/src/main/java/org/birkir/carplay/parser/Parser.kt
+++ b/packages/react-native-carplay/android/src/main/java/org/birkir/carplay/parser/Parser.kt
@@ -36,6 +36,7 @@ import org.birkir.carplay.screens.CarScreenContext
 import org.birkir.carplay.utils.EventEmitter
 import java.util.TimeZone
 import kotlin.math.max
+import androidx.core.graphics.toColorInt
 
 class Parser(
   context: CarContext, carScreenContext: CarScreenContext
@@ -66,7 +67,18 @@ class Parser(
 
     fun parseCarIcon(map: ReadableMap, context: CarContext): CarIcon {
       val bitmap = parseBitmap(map, context)
-      return CarIcon.Builder(IconCompat.createWithBitmap(bitmap)).build()
+      val iconCompat = IconCompat.createWithBitmap(bitmap)
+
+      if (map.hasKey("tintColor") && !map.isNull("tintColor")) {
+        val colorStr = map.getString("tintColor")
+        try {
+          val color = colorStr!!.toColorInt()
+          iconCompat.setTint(color)
+        } catch (e: IllegalArgumentException) {
+        }
+      }
+
+      return CarIcon.Builder(iconCompat).build()
     }
 
     fun parseTravelEstimate(map: ReadableMap): TravelEstimate {

--- a/packages/react-native-carplay/android/src/main/java/org/birkir/carplay/parser/RCTTabTemplate.kt
+++ b/packages/react-native-carplay/android/src/main/java/org/birkir/carplay/parser/RCTTabTemplate.kt
@@ -1,54 +1,170 @@
 package org.birkir.carplay.parser
 
+import android.util.Log
 import androidx.car.app.CarContext
+
+import androidx.car.app.model.Action
+import androidx.car.app.model.CarColor
+import androidx.car.app.model.CarIcon
+import androidx.car.app.model.ItemList
+import androidx.car.app.model.ListTemplate
+import androidx.car.app.model.PlaceMarker
+import androidx.car.app.model.Row
 import androidx.car.app.model.Tab
 import androidx.car.app.model.TabContents
 import androidx.car.app.model.TabTemplate
 import androidx.car.app.model.TabTemplate.TabCallback
+import androidx.car.app.model.Template
+import androidx.core.graphics.drawable.IconCompat
 import com.facebook.react.bridge.ReadableMap
 import org.birkir.carplay.screens.CarScreenContext
+
+
 
 class RCTTabTemplate(
   context: CarContext,
   carScreenContext: CarScreenContext
 ) : RCTTemplate(context, carScreenContext) {
+
+  private val tabContentsMap = mutableMapOf<String, TabContents>()
+  private val tabInfoMap = mutableMapOf<String, TabInfo>()
+  private var currentTemplate: TabTemplate? = null
+  private var activeTabId: String? = null
+  private var isLoading: Boolean = false
+
+  data class TabInfo(val title: String, val icon: CarIcon, val headerAction: Action)
+
   override fun parse(props: ReadableMap): TabTemplate {
-    return TabTemplate.Builder(object : TabCallback {
-      override fun onTabSelected(tabContentId: String) {
-        eventEmitter.didSelectTemplate(tabContentId)
-      }
-    }).apply {
-      setLoading(props.isLoading())
-      props.getArray("templates")?.let {
-        for (i in 0 until it.size()) {
-          it.getMap(i)?.let { tabMap ->
-            addTab(parseTab(tabMap))
-          }
-        }
-        // Apply and select first tab
-        it.getMap(0)?.getString("id")?.let { it1 ->
-          setTabContents(parseTabContents(it1))
-          setActiveTabContentId(it1)
+    tabInfoMap.clear()
+    isLoading = props.isLoading()
+    val builder = TabTemplate.Builder(tabCallback)
+    builder.setLoading(isLoading)
+
+    props.getArray("templates")?.let { templatesArray ->
+      for (i in 0 until templatesArray.size()) {
+        try {
+          val tabProps = templatesArray.getMap(i)
+          parseTabInfo(tabProps, builder)
+        } catch (e: Exception) {
+          Log.e(TAG, "Error parsing tab at index $i", e)
         }
       }
-      props.getMap("headerAction")?.let { setHeaderAction(Parser.parseAction(it, context, eventEmitter)) }
-    }.build()
+
+      // Set first tab as active
+      tabInfoMap.keys.firstOrNull()?.let { firstTabId ->
+        setActiveTab(builder, firstTabId)
+      }
+    }
+
+    currentTemplate = builder.build()
+    return currentTemplate!!
+  }
+
+  private fun parseTabInfo(tabProps: ReadableMap, builder: TabTemplate.Builder) {
+    val id = tabProps.getString("id") ?: return
+    Log.d(TAG, "parseTabInfo: $tabProps")
+    val tab = parseTab(tabProps)
+    builder.addTab(tab)
+
+    Log.d(TAG, "parseTabInfo1: $tab.icon")
+    val headerAction = tabProps.getMap("headerAction")?.let { parseAction(it) } ?: Action.APP_ICON
+    tabInfoMap[id] = TabInfo(tab.title.toString(), tab.icon, headerAction)
+  }
+
+  private fun setActiveTab(builder: TabTemplate.Builder, tabId: String) {
+    builder.setTabContents(getTabContents(tabId))
+    builder.setActiveTabContentId(tabId)
+    builder.setHeaderAction(tabInfoMap[tabId]?.headerAction ?: Action.APP_ICON)
+    activeTabId = tabId
+  }
+
+  private val tabCallback = object : TabCallback {
+    override fun onTabSelected(tabContentId: String) {
+      Log.d(TAG, "Tab selected: $tabContentId")
+      eventEmitter.didSelectTemplate(tabContentId)
+      updateContents(tabContentId)
+    }
+  }
+  private fun buildCurrentTemplate() {
+    val builder = TabTemplate.Builder(tabCallback).setLoading(isLoading)
+
+    tabInfoMap.forEach { (id, info) ->
+      Log.d(TAG, "buildCurrentTemplate: $info")
+      builder.addTab(Tab.Builder()
+        .setTitle(info.title)
+        .setIcon(info.icon)
+        .setContentId(id)
+        .build())
+    }
+
+    activeTabId?.let { activeId ->
+      setActiveTab(builder, activeId)
+    }
+
+    currentTemplate = builder.build()
+  }
+
+  private fun updateContents(tabContentId: String) {
+    Log.d(TAG, "Updating contents for tab: $tabContentId")
+    activeTabId = tabContentId
+    buildCurrentTemplate()
+    // Update the main tab screen with the new template
+    carScreenContext.screens[carScreenContext.screenMarker]?.apply {
+      setTemplate(currentTemplate as Template, true, isSurfaceTemplate = true, sessionLifecycle = lifecycle)
+      invalidate()
+    }
+    Log.d(TAG, "Template updated for tab $tabContentId")
   }
 
   private fun parseTab(props: ReadableMap): Tab {
     return Tab.Builder().apply {
       props.getString("id")?.let { setContentId(it) }
-      props.getString("title")?.let { setTitle(it) }
-      props.getMap("image")?.let { setIcon(Parser.parseCarIcon(it, context)) }
+      val config = props.getMap("config")
+
+      Log.d(TAG, "parseTab: $props")
+
+      when {
+        config != null -> {
+          setTitle(config.getString("tabTitle") ?: DEFAULT_TAB_TITLE)
+          setIcon(Parser.parseCarIcon(config.getMap("tabImage")!!, context))
+        }
+        else -> {
+          setTitle(DEFAULT_TAB_TITLE)
+          setIcon(CarIcon.APP_ICON)
+        }
+      }
     }.build()
   }
 
-  private fun parseTabContents(templateId: String): TabContents {
-    val screen = carScreenContext.screens[templateId]!!
-    return TabContents.Builder(screen.template!!).build()
+  private fun getTabContents(templateId: String): TabContents {
+    return tabContentsMap.getOrPut(templateId) {
+      val screen = carScreenContext.screens[templateId]
+      val template = screen?.template
+
+      when {
+        template != null -> {
+          Log.d(TAG, "Template found for $templateId: $template")
+          TabContents.Builder(template).build()
+        }
+        else -> createDefaultTabContents(templateId)
+      }
+    }
+  }
+
+  private fun createDefaultTabContents(templateId: String): TabContents {
+    val defaultItemList = ItemList.Builder()
+      .addItem(Row.Builder().setTitle("No content available for $templateId").build())
+      .build()
+    val defaultTemplate = ListTemplate.Builder()
+      .setTitle(DEFAULT_CONTENT_TITLE)
+      .setSingleList(defaultItemList)
+      .build()
+    return TabContents.Builder(defaultTemplate).build()
   }
 
   companion object {
     const val TAG = "RCTTabTemplate"
+    private const val DEFAULT_TAB_TITLE = "Untitled Tab"
+    private const val DEFAULT_CONTENT_TITLE = "Default Content"
   }
 }

--- a/packages/react-native-carplay/src/interfaces/GridButton.ts
+++ b/packages/react-native-carplay/src/interfaces/GridButton.ts
@@ -20,6 +20,10 @@ export interface GridButton {
    * When creating a grid button, don't provide an animated image. If you do, the button uses the first image in the animation sequence.
    */
   image: ImageSourcePropType;
+   /**
+    * Image color
+    ** **/
+  tintColor?: string;
 
   disabled?: boolean;
 }

--- a/packages/react-native-carplay/src/templates/Template.ts
+++ b/packages/react-native-carplay/src/templates/Template.ts
@@ -181,9 +181,13 @@ export class Template<P> {
         if (obj[key] != null && typeof obj[key] === 'object') {
           traverse(obj[key]);
         }
-        if (key === 'image') {
+        if (key === 'image' || key === "tabImage") {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-          obj[key] = Image.resolveAssetSource(obj[key]);
+          const resolved = Image.resolveAssetSource(obj[key]);
+          obj[key] = {
+            ...resolved,
+            ...(obj["tintColor"] && obj["tintColor"] != null ? {tintColor: obj["tintColor"]} : {}),
+          };
         }
       }
     }


### PR DESCRIPTION
- Added `tintColor` support for icons.
- Refactor `RCTTabTemplate` to support dynamic tab switching.
- Updated `.npmignore` to exclude build artifacts and sensitive files.
